### PR TITLE
FIX: circle ci release pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,8 @@ jobs:
             mvn versions:set -DnewVersion=${VERSION} versions:commit
           fi
       - run:
-          name: Build and Test
-          command: mvn -s .circleci/settings.xml -B deploy -DskipTests
+          name: Deploy
+          command: mvn -f guitests-selenium-framework/pom.xml -s .circleci/settings.xml -B deploy -DskipTests
 workflows:
   version: 2
   build-n-deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea/
-/guitests-selenium-framework/guitests-selenium-framework.iml
-/guitests-selenium-example/guitests-selenium-example.iml
-/guitests-selenium-framework/target/
+*.iml
+*.ipr
+*.iws
+**/target/

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,5 @@
+= GUITestsSelenium
+
+image:https://circleci.com/gh/gorob/GUITestsSelenium/tree/master.svg?style=shield["CircleCI", link="https://circleci.com/gh/gorob/GUITestsSelenium/tree/master"]
+image:https://img.shields.io/badge/License-MIT-yellow.svg["MIT License", link="https://opensource.org/licenses/MIT"]
+image:https://api.bintray.com/packages/gorob/GUITestsSelenium/GUITestsSelenium/images/download.svg[link="https://bintray.com/gorob/GUITestsSelenium/GUITestsSelenium/_latestVersion"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,0 @@
-# GUITestsSelenium
-
-TODO

--- a/guitests-selenium-example/pom.xml
+++ b/guitests-selenium-example/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>com.gorob</groupId>
             <artifactId>guitests-selenium-framework</artifactId>
-            <version>1.3.0</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/guitests-selenium-framework/pom.xml
+++ b/guitests-selenium-framework/pom.xml
@@ -53,6 +53,15 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
I added missed execution block for javadoc, so you have javadoc, source and jar for bintray.
I recommend only deploy framework to bintray.